### PR TITLE
feat: automated country add

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,17 @@
 run-local:
 	docker-compose up
+
 down:
 	docker-compose down
+
 build:
 	@docker-compose up --build
+
 clean:
 	docker-compose stop && docker-compose rm -f
+
 rebuild:	clean	build
+
+add-country:
+	sudo chmod +x ./scripts/create-country-template.sh
+	./scripts/create-country-template.sh $(COUNTRY)

--- a/scripts/create-country-template.sh
+++ b/scripts/create-country-template.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+
+[ $# -ne 1 ] && {
+    echo -e "\nfailed: please insert a valid ISO3 code from country"
+    echo -e "run: make add-country COUNTRY=[ISO3 Code from Country]"
+    echo -e "\t- Example:  $ make add-country COUNTRY=usa\n"
+    exit 1
+}
+
+country=$1
+regex=$(grep -n "^[a-zA-Z][a-zA-Z][a-zA-Z]$" <<< $country)
+
+[ $regex -z ] && {
+    echo -e "\nfailed: [$country] not ISO3 valid code, please insert a valid ISO3 code from country"
+    echo -e "run: make add-country COUNTRY=[ISO3 Code from Country]"
+    echo -e "\t- Example:  $ make add-country COUNTRY=usa\n"
+    exit 1
+}
+
+echo -e "\n> create template from [$country]"
+
+CREATE_DIR=scripts/$country
+CORRECT_DIR=src/countries/countries
+
+mkdir -p $CREATE_DIR
+echo "> create helpers dir from [$country]"
+mkdir -p $CREATE_DIR/helpers
+
+COUNTRY_UPPER=${country^^}
+model=$( cat scripts/model.txt )
+echo "> create index.js file from [$COUNTRY_UPPER] class"
+echo "${model//TOKEN/$COUNTRY_UPPER}" > $CREATE_DIR/index.js
+
+echo "> move from [$CORRECT_DIR]"
+mv $CREATE_DIR $CORRECT_DIR
+
+
+FILE_ADD_REFERENCE=src/countries/index.js
+echo -e "> add reference from class [$COUNTRY_UPPER] file in [$FILE_ADD_REFERENCE]"
+
+REFERENCE_LINE="const countryObjectReferences = {"
+line_ref=$( grep -n "^$REFERENCE_LINE$" $FILE_ADD_REFERENCE | cut -d : -f 1 )
+#Next line is the correct to add import
+((line_ref=line_ref+1))
+
+
+reference_text="$country: $COUNTRY_UPPER,"
+awk -v x="$reference_text" -v line="$line_ref" 'NR==line{print x} 1' $FILE_ADD_REFERENCE > tmp && mv tmp $FILE_ADD_REFERENCE
+
+
+import_text="import $COUNTRY_UPPER from './countries/$country';"
+awk -v x="$import_text" -v line="1" 'NR==line{print x} 1' $FILE_ADD_REFERENCE > tmp && mv tmp $FILE_ADD_REFERENCE
+
+
+echo -e "> complete\n"

--- a/scripts/model.txt
+++ b/scripts/model.txt
@@ -1,0 +1,25 @@
+import { add } from 'date-fns';
+import Country from '../../../models/Country';
+import months from '../../constants';
+
+class TOKEN extends Country {
+  constructor(year) {
+    super('Country Name', 'Oficial Country Name');
+    this.STATES = [];
+    this.populate(year);
+  }
+
+  populate(year) {
+    //Example
+    super.addHoliday(new Date(year, months.JAN, 1), 'New Year');
+  }
+
+  getStates() {
+    return {
+      first: this.STATES[0],
+      size: this.STATES.length,
+    };
+  }
+}
+
+export default TOKEN;


### PR DESCRIPTION
## Description

Com a nova estrutura implementada no PR #16, podemos automatizar a tarefa base para adição ao suporte de novos países. Este PR insere um script base para realizar a criação automática e inserção das referências corretas, facilitando o desenvolvimento de novos países.

Funcionamento básico do script:
- Filtra o nome do país inserido de acordo com o regex: `^[a-zA-Z][a-zA-Z][a-zA-Z]$`
- Cria um diretório com este nome
  - Cria um subdiretório de nome `helpers`
  - Cria um arquivo `index.js` preenchido com o modelo
  - Substitui o token pelo código do país
- Insere o import a esta nova dependência no "arquivo de proxy"
- Insere a estrutura de referência também no "arquivo de proxy"